### PR TITLE
Releasing new Pulsar chart version 1.0.15

### DIFF
--- a/examples/dev-values.yaml
+++ b/examples/dev-values.yaml
@@ -32,7 +32,7 @@ broker:
 autoRecovery:
   resources:
     requests:
-      memory: 1Gi
+      memory: 512Mi
       cpu: 1
 
 function:

--- a/helm-chart-sources/pulsar/templates/bastion-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion-configmap.yaml
@@ -38,7 +38,7 @@ data:
   {{- if .Values.secrets }}
   tlsTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}
-  tlsTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+  tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
 {{ toYaml .Values.bastion.configData | indent 2 }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-configmap.yaml
@@ -63,7 +63,7 @@ data:
   {{- if .Values.secrets }}
   tlsTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}
-  tlsTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+  tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
   tlsProtocols: "TLSv1.2,TLSv1.1"
   brokerServicePortTls: "6651"
@@ -71,7 +71,7 @@ data:
   {{- if .Values.secrets }}
   brokerClientTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}
-  brokerClientTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+  brokerClientTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
   PF_pulsarServiceUrl: "pulsar+ssl://localhost:6651"
   PF_pulsarWebServiceUrl: "https://localhost:8443"

--- a/helm-chart-sources/pulsar/templates/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment.yaml
@@ -36,6 +36,10 @@ spec:
       app: {{ template "pulsar.name" . }}
       release: {{ .Release.Name }}
       component: {{ .Values.broker.component }}
+{{- if .Values.proxy.updateStrategy }}
+  strategy:
+{{ toYaml .Values.proxy.updateStrategy | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm-chart-sources/pulsar/templates/dns-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/dns-deployment.yaml
@@ -1,11 +1,14 @@
 {{- if .Values.extra.usedns }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.dns.component }}"
 spec:
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: "{{ template "pulsar.fullname" . }}-{{ .Values.dns.component }}"
   template:
     metadata:
       labels:
@@ -35,4 +38,9 @@ spec:
         - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
         - --registry=txt
         - --txt-owner-id=my-identifier
+        {{- if eq .Values.dns.provider "digitalocean" }}
+        env:
+        - name: DO_TOKEN
+          value: "{{ .Values.dns.digitalOceanApiKey}}"
+        {{- end  }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function-configmap.yaml
@@ -45,7 +45,7 @@ data:
     {{- if .Values.secrets }}
     tlsTrustCertsFilePath: /pulsar/certs/ca.crt
     {{- else }}
-    tlsTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+    tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
     {{- end }}
     tlsKeyFilePath: "/pulsar/tls-pk8.key"
     tlsAllowInsecureConnection: "true"

--- a/helm-chart-sources/pulsar/templates/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy-configmap.yaml
@@ -54,14 +54,14 @@ data:
   {{- if .Values.secrets }}
   tlsTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}
-  tlsTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+  tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
   tlsProtocols: "TLSv1.2,TLSv1.1"
   tlsEnabledWithBroker: "true"
   {{- if .Values.secrets }}
   brokerClientTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}
-  brokerClientTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+  brokerClientTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
   brokerServicePortTls: "6651"
   webServicePortTls: "8443"

--- a/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
@@ -37,6 +37,10 @@ spec:
       app: {{ template "pulsar.name" . }}
       release: {{ .Release.Name }}
       component: {{ .Values.proxy.component }}
+  {{- if .Values.proxy.updateStrategy }}
+  strategy:
+{{ toYaml .Values.proxy.updateStrategy | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -95,7 +99,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}
-      {{- if or (.Values.enableTls) (.Values.enableTokenAuth) }}
+      {{- if or .Values.enableTls (or .Values.enableTokenAuth .Values.proxy.initContainer) }}
       volumes:
       {{- end }}
         {{- if .Values.enableTls }}
@@ -168,7 +172,15 @@ spec:
         {{- if .Values.proxy.probe }}
         readinessProbe:
           tcpSocket:
+          {{- if .Values.proxy.probe.port }}
             port: {{ .Values.proxy.probe.port }}
+          {{- else }}
+            {{- if .Values.enableTls }}
+            port: 8443
+            {{- else }}
+            port: 8080
+            {{- end }}
+          {{- end }}
           initialDelaySeconds: {{ .Values.proxy.probe.initial }} 
           periodSeconds:  {{ .Values.proxy.probe.period }} 
         {{- end }}
@@ -188,7 +200,7 @@ spec:
         ports:
         - name: http
           containerPort: 8080
-        {{- if or .Values.enableTls .Values.enableTokenAuth }}
+        {{- if or (or .Values.enableTls .Values.enableTokenAuth) .Values.proxy.initContainer }}
         volumeMounts:
         {{- end }}
           {{- if .Values.enableTls }}
@@ -206,11 +218,12 @@ spec:
           {{- end }}
           {{- if .Values.proxy.initContainer }}
           - name: lib-data
-            mountPath: /jars
+            mountPath: "/jars"
           {{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+{{- if .Values.extra.wsproxy }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-ws"
         image: "{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}"
         imagePullPolicy: {{ .Values.image.proxy.pullPolicy }}
@@ -255,6 +268,7 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-ws"
+{{- end }}
 {{- if .Values.extra.wsAuthServer }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-wsauth"
         image: "{{ .Values.image.wsAuthProxy.repository }}:{{ .Values.image.wsAuthProxy.tag }}"

--- a/helm-chart-sources/pulsar/templates/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy-ws-configmap.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.extra.proxy }}
+{{- if .Values.extra.wsproxy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -64,7 +64,7 @@ data:
   {{- if .Values.secrets }}
   tlsTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}
-  tlsTrustCertsFilePath: "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+  tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
 {{- end }}
 {{ toYaml .Values.proxy.configData | indent 2 }}

--- a/helm-chart-sources/pulsar/templates/pulsar-express-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-express-configmap.yaml
@@ -16,10 +16,19 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+{{- if .Values.extra.pulsarexpress }}
 apiVersion: v1
-appVersion: "1.0"
-description: Apache Pulsar Helm chart for Kubernetes
-name: pulsar
-icon: https://kafkaesque.io/wp-content/uploads/2019/04/color_logo_with_background.svg
-version: 1.0.15
+kind: ConfigMap
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsarexpress.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+data:
+{{ toYaml .Values.pulsarexpress.configData | indent 2 }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsar-express-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-express-deployment.yaml
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.extra.pulsarexpress }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsarexpress.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "pulsar.name" . }}
+      release: {{ .Release.Name }}
+      component: {{ .Values.pulsarexpress.component }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "pulsar.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ .Values.pulsarexpress.component }}
+        cluster: {{ template "pulsar.fullname" . }}
+      annotations:
+{{ toYaml .Values.pulsarexpress.annotations | indent 8 }}
+    spec:
+    {{- if .Values.pulsarexpress.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pulsarexpress.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.pulsarexpress.tolerations }}
+      tolerations:
+{{ toYaml .Values.pulsarexpress.tolerations | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.pulsarexpress.gracePeriod }}
+      containers:
+        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+          image: "{{ .Values.image.pulsarexpress.repository }}:{{ .Values.image.pulsarexpress.tag }}"
+          imagePullPolicy: {{ .Values.image.pulsarexpress.pullPolicy }}
+        {{- if .Values.pulsarexpress.resources }}
+          resources:
+{{ toYaml .Values.pulsarexpress.resources | indent 12 }}
+        {{- end }}
+          ports:
+          - containerPort: 9527
+          volumeMounts:
+          - name: pulsarexpress-data
+            mountPath: /data
+          envFrom:
+          - configMapRef:
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+          env:
+          {{- if .Values.enableTls }}
+          - name: PE_CONNECTION_URL
+            value: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443
+          {{- else }}
+          - name: PE_CONNECTION_URL
+            value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080
+          {{- end }}
+          {{- if .Values.enableTokenAuth }}
+          - name: PE_CONNECTION_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: token-superuser
+                key: superuser.jwt 
+          {{- end }}
+          {{- if .Values.extra.function }}
+          - name: PE_CONNECTION_FCT_WORKER_URL
+            value: http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}:6750
+          {{- end }}
+      volumes:
+        - name: pulsarexpress-data
+          emptyDir: {}
+
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsar-express-ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-express-ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.extra.pulsarexpress }}
+{{- if .Values.pulsarexpress.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsarexpress.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+  annotations:
+{{ toYaml .Values.pulsarexpress.ingress.annotations | indent 4 }}
+spec:
+  rules:
+    - host: {{ .Values.pulsarexpress.ingress.host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+              servicePort: 3000
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsar-express-service.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-express-service.yaml
@@ -17,9 +17,27 @@
 # under the License.
 #
 
+{{- if .Values.extra.pulsarexpress }}
 apiVersion: v1
-appVersion: "1.0"
-description: Apache Pulsar Helm chart for Kubernetes
-name: pulsar
-icon: https://kafkaesque.io/wp-content/uploads/2019/04/color_logo_with_background.svg
-version: 1.0.15
+kind: Service
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarexpress.component }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.pulsarexpress.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+  annotations:
+{{ toYaml .Values.pulsarexpress.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.pulsarexpress.service.type }}
+  ports:
+{{ toYaml .Values.pulsarexpress.service.ports | indent 2 }}
+  selector:
+    app: {{ template "pulsar.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.pulsarexpress.component }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
@@ -36,7 +36,7 @@ spec:
         value: /pulsar/certs/ca.crt
       {{- else }}
       - name: tlsTrustCertsFilePath
-        value:  "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+        value:  "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
       {{- end }}
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["sh", "-c"]

--- a/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
@@ -37,7 +37,7 @@ spec:
         value: /pulsar/certs/ca.crt
       {{- else }}
       - name: tlsTrustCertsFilePath
-        value:  "/etc/ssl/certs/{{ .Values.tlsCaCert }}"
+        value:  "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
       {{- end }}
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["sh", "-c"]

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -93,9 +93,26 @@ tlsSecretName: pulsar-tls
   # certificate: |
   # caCertificate: |
 
+# If you are using an external source to populate the TLS certifcate (ex cert-manager),
+# enter the path and name to the CA cert. This is required so that the components
+# within the cluster (proxy, broker, etc) can talk to each other
+#
+# If you are using self-signed certs, the CA will be contained within the tlsSecretName above,
+# so use the following settings:
+#
+# tlsCaPath: /pulsar/certs
+# tlsCaCert: ca.crt
+# 
+# If your certificate is signed by public CA (ex Let's Encrypt), then you can use
+# the standard CA store from the container OS using the following settings:
+
+tlsCaPath: /etc/ssl/certs
+tlsCaCert: ca-certificates.crt
+
 superUserRoles: superuser,admin,websocket,proxy
 proxyRoles: proxy
-tlsCaCert: ca-certificates.crt
+
+
 
 # Enable token-based authentication and authorization
 enableTokenAuth: no
@@ -117,6 +134,8 @@ enableTests: no
 extra:
   # Pulsar proxy
   proxy: yes
+  # Websocket proxy
+  wsproxy: yes
   # Standalone functions worker
   function: no 
   # Standalone state storage
@@ -134,6 +153,8 @@ extra:
   monitoring: no
   # Zoonavigator
   zoonavigator: no
+  # Pulsar manager UI for admin
+  pulsarexpress: no
   
 ## Which images to use
 image:
@@ -162,6 +183,10 @@ image:
     repository: apachepulsar/pulsar
     pullPolicy: IfNotPresent
     tag: 2.5.0
+  pulsarexpress:
+    repository: kafkaesqueio/pulsar-express
+    tag: 0.5.1_k2
+    pullPolicy: IfNotPresent
   # Standalone state storage is experimental and requires the custom image below 
   stateStorage:
     repository: kafkaesqueio/pulsar-all
@@ -439,6 +464,7 @@ bookkeeper:
 broker:
   component: broker
   replicaCount: 3
+  updateStrategy: {}
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
     #
@@ -657,6 +683,7 @@ proxy:
   component: proxy
   replicaCount: 3
   disableZookeeperDiscovery: yes
+  updateStrategy: {}
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   annotations:
@@ -666,7 +693,6 @@ proxy:
   #preferredZone: "us-east1-c"
   gracePeriod: 0
   probe:
-    port: 8080
     initial: 10
     period: 10
   # Resources for the main Pulsar proxy
@@ -794,6 +820,36 @@ dashboard:
     ports:
     - name: server
       port: 80
+
+## Components Stack: pulsarexpress
+## templates/pulsarexpress.yaml
+##
+pulsarexpress:
+  component: pulsarexpress
+  replicaCount: 1
+  ingress:
+    enabled: yes
+    host: ui.host.com
+    annotations: {}
+  # nodeSelector:
+  # cloud.google.com/gke-nodepool: default-pool
+  annotations: {}
+  tolerations: []
+  gracePeriod: 0
+  resources:
+    requests:
+      memory: 250Mi
+      cpu: 0.1
+  configData: {}
+  ## Pulsar Express service
+  ## templates/pulsarexpress-service.yaml
+  ##
+  service:
+    type: ClusterIP
+    annotations: {}
+    ports:
+      - name: server
+        port: 3000
 
 ## Pulsar Extra: Zoonavigator
 ## templates/zoonavigator-deployment.yaml


### PR DESCRIPTION
* Adding Pulsar Express to cluster

* Make path to CA cert configurable to support self-signed certs with cert-manager

* Ability to disalbe WS proxy; sensible default for proxy readiness probe

* Support for DO; compat with k8s 1.16

* Configurable upgrade strategy for broker and proxy

* Rename file

* Update the README for Pulsar Express plus

* Bumping the version to prepare for release