### PR TITLE
Zone anti affinity

### DIFF
--- a/examples/dev-values.yaml
+++ b/examples/dev-values.yaml
@@ -26,8 +26,6 @@ broker:
     requests:
       memory: 512Mi
       cpu: 0.3
-  probe:
-    enabled: no 
   configData:
     PULSAR_MEM: "\"-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem\""
 

--- a/helm-chart-sources/pulsar/templates/autorecovery-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery-deployment.yaml
@@ -62,6 +62,7 @@ spec:
       affinity:
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -76,8 +77,29 @@ spec:
               - key: "component"
                 operator: In
                 values:
-                - {{ .Values.bookkeeper.component }}
+                - {{ .Values.autoRecovery.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.autoRecovery.component }}
+          {{- end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.autoRecovery.gracePeriod }}
       initContainers:

--- a/helm-chart-sources/pulsar/templates/beamwh-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/beamwh-deployment.yaml
@@ -59,6 +59,48 @@ spec:
       tolerations:
 {{ toYaml .Values.beamwh.tolerations | indent 8 }}
     {{- end }}
+     affinity:
+        {{- if .Values.enableAntiAffinity }}
+        podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.beamwh.component }}
+            topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.beamwh.component }}
+          {{- end }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.beamwh.gracePeriod }}
       volumes:
         {{- if .Values.enableTokenAuth }}
@@ -121,10 +163,12 @@ spec:
             value: {{ .Values.dnsName }}
           - name: SuperRoles
             value: {{ .Values.tokenServer.allowedRoles }}
+          {{- if .Values.enableTokenAuth }}
           - name: PulsarPublicKey
             value: "/pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
           - name: PulsarPrivateKey
             value: "/pulsar/token-private-key/{{ .Values.tokenPrivateKeyFile }}"
+          {{- end }}
           - name: PbDbType
             value: {{ .Values.beamwh.dbType }}
           - name: DbName

--- a/helm-chart-sources/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
       affinity:
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -82,6 +83,27 @@ spec:
                 values:
                 - {{ .Values.bookkeeper.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.bookkeeper.component }}
+          {{- end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
       initContainers:

--- a/helm-chart-sources/pulsar/templates/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment.yaml
@@ -77,6 +77,7 @@ spec:
         {{- end }}
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -93,6 +94,27 @@ spec:
                 values:
                 - {{ .Values.broker.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.broker.component }}
+          {{- end }}  
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.broker.gracePeriod }}
       volumes:

--- a/helm-chart-sources/pulsar/templates/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function-statefulset.yaml
@@ -79,6 +79,7 @@ spec:
         {{- end }}
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -95,6 +96,27 @@ spec:
                 values:
                 - {{ .Values.function.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.function.component }}
+          {{- end }} 
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.function.gracePeriod }}
       volumes:

--- a/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
@@ -81,6 +81,7 @@ spec:
         {{- end }}
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -97,6 +98,27 @@ spec:
                 values:
                 - {{ .Values.proxy.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.proxy.component }}
+          {{- end }} 
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}
       {{- if or .Values.enableTls (or .Values.enableTokenAuth .Values.proxy.initContainer) }}
@@ -337,15 +359,19 @@ spec:
         - name: pulsarbeam
           containerPort: 8085
         volumeMounts:
+          {{- if .Values.enableTls }}
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
+          {{- end }}
+          {{- if .Values.enableTokenAuth }}
           - mountPath: "/pulsar/token-private-key"
             name: token-private-key
             readOnly: true
           - mountPath: "/pulsar/token-public-key"
             name: token-public-key
             readOnly: true
+          {{- end }}
         args: ["-mode", "http"]
         env:
           - name: ProcessMode
@@ -356,18 +382,11 @@ spec:
             value: "{{ .Values.dnsName }}"
           - name: SuperRoles
             value: {{ .Values.tokenServer.allowedRoles }}
+          {{- if .Values.enableTokenAuth }}
           - name: PulsarPublicKey
             value: "/pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
           - name: PulsarPrivateKey
             value: "/pulsar/token-private-key/{{ .Values.tokenPrivateKeyFile }}"
-          - name: PbDbType
-            value: {{ .Values.pulsarBeam.dbType }}
-          - name: DbName
-            value: {{ .Values.pulsarBeam.dbName }}
-          - name: DbPassword
-            value: {{ .Values.pulsarBeam.dbPassword }}
-          - name: DbConnectionStr
-            value: {{ .Values.pulsarBeam.dbConnectionStr }}
-
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/state-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/state-statefulset.yaml
@@ -78,6 +78,7 @@ spec:
         {{- end }}
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -94,6 +95,27 @@ spec:
                 values:
                 - {{ .Values.stateStorage.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.stateStorage.component }}
+          {{- end }} 
         {{- end }}   
       terminationGracePeriodSeconds: {{ .Values.stateStorage.gracePeriod }}
       containers:

--- a/helm-chart-sources/pulsar/templates/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-statefulset.yaml
@@ -65,6 +65,7 @@ spec:
       affinity:
         {{- if .Values.enableAntiAffinity }}
         podAntiAffinity:
+          {{- if .Values.antiAffinity.host.enabled }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
@@ -81,6 +82,27 @@ spec:
                 values:
                 - {{ .Values.zookeeper.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.antiAffinity.zone.enabled }}
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 100  
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.zookeeper.component }}
+          {{- end }} 
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
       containers:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -76,6 +76,11 @@ prometheus_rbac: yes
 #     kind: Managed
 #     cachingmode: ReadOnly
 
+# TLS
+# When you enable TLS and are using a proxy, you need to expose the 
+# TLS-enabled ports. To allow TLS connections only, remove the plain-text ports.
+# See the proxy section for details.
+
 enableTls: no
 tlsSecretName: pulsar-tls
 
@@ -123,9 +128,24 @@ tokenPublicKeyFile: my-public.key
 # Token private key file name
 tokenPrivateKeyFile: my-private.key
 
-# Turn on anti affinity rules so that pods don't get scheduled on the same node
-# In development environments with a single node, this need to be disabled
+# Turn on anti affinity rules so that replica pods are spread for 
+# high availablity.
+# In development environments (ex. Minikube) with a single node, this needs to be disabled
 enableAntiAffinity: yes
+
+# Settings for anti-affinity. Host antiAffinity ensures that 
+# replica pods are scheduled on different hosts. The
+# number of hosts >= number of replicas
+#
+# Zone antiAffinity distributes replica pods across availability 
+# zones. This is a "soft" requirement, so that in the event of 
+# a failure of a zone, pods will run in a different zone
+antiAffinity:
+  host:
+    enabled: yes
+  zone:
+    enabled: no
+  
 
 # Install Helm tests (run with helm test <release>)
 enableTests: no
@@ -162,18 +182,38 @@ extra:
   autoRecovery: yes
   # Bastion pod for administrative commands
   bastion: yes
-  # Pulsar-beam webhook brokers
+  # Pulsar Beam webhook brokers
   beamwh: no
-  # Pulsar-beam http component and rest api
+  # Pulsar Beam http component and rest api
+  # For external access via the proxy you need to expose
+  # the Pulsar Beam port. See the proxy section for details.
   pulsarBeam: no
-  # Monitoring stack (prometheus, grafana, and dashboard)
-  monitoring: no
-  # Zoonavigator
-  zoonavigator: no
   # Pulsar manager UI for admin
   pulsarexpress: no
+  # Zoonavigator for debugging Zookeeper
+  zoonavigator: no
+  #
+  # DEPRECATED
+  # Support for the monitoring extra is deprecated
+  # and will be removed in a future release.
+  #
+  # Maintaining Helm support for prometheus and grafana in this chart
+  # makes little sense when there are stable charts that are
+  # actively maintained that do a better job. The Prometheus 
+  # Operator Helm chart is recommended for monitoring since it 
+  # has a rich feature set and the latest versions and features.
+  #
+  # The pulsar dashboard is deprecated by the Pulsar project. This 
+  # chart includes Pulsar Express as an alternative.
+  #
+  # Monitoring stack (prometheus, grafana, and dashboard)
+  monitoring: no
   
 ## Which images to use
+# When upgrading a Pulsar cluster, it is recommended to upgrade the 
+# components one at a time (zookeeper, bookkeeper, broker, etc). 
+# This section allows for targeted upgrades of each component.
+#
 image:
   broker:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
@@ -764,16 +804,30 @@ proxy:
   #   ports:
   #   - name: http
   #     port: 8080
-  #     nodePort: 30001
   #     protocol: TCP
   #   - name: pulsar
   #     port: 6650
   #     protocol: TCP
-  #     nodePort: 30002
   #   - name: ws
   #     port: 8000
   #     protocol: TCP
-  #     nodePort: 30003
+
+  # If you are enabling TLS, add these ports:
+  #   - name: https
+  #     port: 8443
+  #     protocol: TCP
+  #   - name: pulsarssl
+  #     port: 6651
+  #     protocol: TCP
+  #   - name: wss
+  #     port: 8001
+  #     protocol: TCP
+
+  # If you are enabling Pulsar Beam, add this port:
+  #   - name: pulsarbeam
+  #     port: 8085
+  #     protocol: TCP
+
 
   ## Proxy cluster service
   ## templates/proxy-service.yaml


### PR DESCRIPTION
Create a configuration option that enables zone anti-affinity for when running in multi-AZ setups. This will ensure that pods are equally spread between zones.