### PR TITLE
add burnell function log collector

### DIFF
--- a/helm-chart-sources/pulsar/templates/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function-statefulset.yaml
@@ -215,6 +215,27 @@ spec:
             subPath: functions_worker.yml
           - name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-{{ .Values.function.volumes.data.name }}"
             mountPath: /pulsar/logs
+{{- if .Values.extra.burnellLogCollector }}
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-burnell"
+        image: "{{ .Values.image.burnellLogCollector.repository }}:{{ .Values.image.burnellLogCollector.tag }}"
+        imagePullPolicy: {{ .Values.image.burnellLogCollector.pullPolicy }}
+        {{- if .Values.function.burnellLogCollectorResources }}
+        resources:
+{{ toYaml .Values.function.burnellLogCollectorResources | indent 10 }}
+        {{- end }}
+        ports:
+        - name: burnelllog
+          containerPort: 4040
+        env:
+          - name: LogServerPort
+            value: ":4040"
+          - name: FunctionLogPathPrefix
+            value: "/pulsar/log/functions/"
+        volumeMounts:
+          - name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-{{ .Values.function.volumes.data.name }}"
+            mountPath: /pulsar/logs
+            readOnly: true
+{{- end }}
   {{- if .Values.persistence }}
   volumeClaimTemplates:
   - metadata:

--- a/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
@@ -482,6 +482,7 @@ spec:
             value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/admin/v2"
           - name: AdminRestPrefix
             value: {{ .Values.burnell.adminRestAPIPrefix | default "/admin/v2" }}
-
+          - name: FunctionWorkerDomain
+            value: ".{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local"
 {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -260,6 +260,10 @@ image:
     repository: kafkaesqueio/burnell
     pullPolicy: Always
     tag: 0.2.2
+  burnellLogCollector:
+    repository: kafkaesqueio/burnell-logcollector
+    pullPolicy: IfNotPresent
+    tag: 0.2.0
   pulsarexpress:
     repository: kafkaesqueio/pulsar-express
     tag: 0.5.1_k2


### PR DESCRIPTION
This is to deploy `burnell`'s function log retrieval feature. It adds a `burnell` log collector container in the function pod to collect function logs. It also enables `burnell` RestAPI for log retrieval. Burnell uses function pod's FQDN for connection.