### PR TITLE
Fix the syntax of the condition to conform with go 1.14

### DIFF
--- a/helm-chart-sources/pulsar/templates/autorecovery-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.autoRecover.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.autoRecovery.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.bastion.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.bastion.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.bookkeeper.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.bookkeeper.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment.yaml
@@ -59,7 +59,7 @@ spec:
       {{- if .Values.broker.serviceAccountName }}
       serviceAccountName: {{ .Values.broker.serviceAccountName }}
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.broker.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.broker.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy-deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- if .Values.extra.kubectlProxy }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-kubectl-proxy"
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.proxy.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.proxy.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-metadata.yaml
@@ -38,7 +38,7 @@ spec:
         nodeAffinity:
 {{ toYaml .Values.zookeeper.nodeAffinity | indent 10 }}
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.zookeeper.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.zookeeper.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.zookeeper.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.zookeeper.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}


### PR DESCRIPTION
Go 1.14 has become less forgiving on some incorrect syntax and with the current versions of helm which were compiled with go 1.14, lots of helm charts are breaking, including this one.

I've edited the templates to change the conditionals to pass the 1.14 parser, and fixed a simple typo s/autoRecover/autoRecovery/ 

Another example of this in a separate helm chart for reference:

https://github.com/rook/rook/issues/5378