### PR TITLE
change update to comply with golang 1.14 improvement

### DIFF
--- a/helm-chart-sources/pulsar-monitor/values.yaml
+++ b/helm-chart-sources/pulsar-monitor/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: kesque/pulsar-monitor
-  tag: 1.0.8
+  tag: 1.2.8
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/helm-chart-sources/pulsar/templates/beamwh-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/beamwh-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.pulsarBeam.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.autoRecovery.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/deprecated/dashboard-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/deprecated/dashboard-deployment.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
 {{ toYaml .Values.dashboard.annotations | indent 8 }}
     spec:
-    {{- if (.Values.nodeSelector) and (eq .Values.dashboard.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.dashboard.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/deprecated/latencyMonitor-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/deprecated/latencyMonitor-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       annotations:
 {{ toYaml .Values.latencymonitor.annotations | indent 8 }}
     spec:
-    {{- if (.Values.nodeSelector) and (eq .Values.latencymonitor.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.latencymonitor.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/deprecated/prometheus-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/deprecated/prometheus-deployment.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
 {{ toYaml .Values.prometheus.annotations | indent 8 }}
     spec:
-    {{- if (.Values.nodeSelector) and (eq .Values.prometheus.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.prometheus.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/deprecated/state-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/deprecated/state-statefulset.yaml
@@ -59,7 +59,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-      {{- if (.Values.nodeSelector) and (eq .Values.stateStorage.nodeSelector false) }}
+      {{- if and (.Values.nodeSelector) (not .Values.stateStorage.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/dns/dns-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/dns/dns-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}
-      {{- if (.Values.nodeSelector) and (eq .Values.dns.nodeSelector false) }}
+      {{- if and (.Values.nodeSelector) (not .Values.dns.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
       priorityClassName: pulsar-priority
       {{- end }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
-      {{- if (.Values.nodeSelector) and (eq .Values.function.nodeSelector false) }}
+      {{- if and (.Values.nodeSelector) (not .Values.function.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsar-express-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-express-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         nodeAffinity:
 {{ toYaml .Values.pulsarexpress.nodeAffinity | indent 10 }}
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.pulsarexpress.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.pulsarexpress.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/zoonavigator/zoonavigator-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/zoonavigator/zoonavigator-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         nodeAffinity:
 {{ toYaml .Values.zoonavigator.nodeAffinity | indent 10 }}
       {{- end }}
-    {{- if (.Values.nodeSelector) and (eq .Values.zoonavigator.nodeSelector false) }}
+    {{- if and (.Values.nodeSelector) (not .Values.zoonavigator.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -277,10 +277,6 @@ extra:
   #
   # Monitoring stack (prometheus, grafana, and dashboard)
   monitoring: no
-  # Zoonavigator
-  zoonavigator: no
-  # Pulsar manager UI for admin
-  pulsarexpress: no
   
 ## Which images to use
 # When upgrading a Pulsar cluster, it is recommended to upgrade the 


### PR DESCRIPTION
To address https://github.com/kafkaesque-io/pulsar-helm-chart/issues/71 and https://github.com/kafkaesque-io/pulsar-helm-chart/issues/72

Since go 1.14 has introduced new error reporting of  a parenthesized argument used as a function, described at https://golang.org/doc/go1.14, the template file needs to be updated.
```
The text/template package now correctly reports errors when a parenthesized argument is used as a function. This most commonly shows up in erroneous cases like {{if (eq .F "a") or (eq .F "b")}}. This should be written as {{if or (eq .F "a") (eq .F "b")}}. The erroneous case never worked as expected, and will now be reported with an error can't give argument to non-function.
```
helm3.4 is based on go1.14.10. This is how the problem were found with helm3.4 installation