### PR TITLE
add initContainer for pulsar-monitor

### DIFF
--- a/helm-chart-sources/pulsar/templates/pulsar-monitor-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-monitor-deployment.yaml
@@ -43,6 +43,19 @@ spec:
         - name: config-volume
           configMap:
             name: "{{ include "pulsar.fullname" . }}-{{ .Values.pulsarMonitor.component }}-config"
+      initContainers:
+      {{- if .Values.pulsarMonitor.enableWaitContainers | default true }}
+      # This init container will wait for bookkeeper to be ready before
+      - name: wait-bookkeeper-ready
+        image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
+        imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
+        command: ["sh", "-c"]
+        args:
+          - >-
+            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080; do
+              sleep 3;
+            done;
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
Add an initContainer to pulsar-monitor that depends on the broker, the broker admin url 8080, to be up. It prevents premature alerting.  Pulsar Monitor container does not start until the broker admin url is ready. 

In the case broker is unavailable, restarting pulsar-monitor will be stuck in initContainer to wait until the broker is ready. Therefore, user can still be alerted by Pulsar Monitor's heartbeat mis-filing.

initContainer dependency can be skipped by disabling `.Values.pulsarMonitor.enableWaitContainer"