### PR TITLE
use latest burnell and monitor image in CI

### DIFF
--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -13,11 +13,11 @@ image:
   pulsarMonitor:
     repository: kesque/pulsar-monitor
     pullPolicy: IfNotPresent
-    tag: 1.2.91
+    tag: latest
   burnell:
     repository: kesque/burnell
     pullPolicy: IfNotPresent
-    tag: 1.2.54
+    tag: latest
 
 zookeeper:
   resources:


### PR DESCRIPTION
Always use and test the latest image from Burnell and Pulsar Monitor in CI