### PR TITLE
Add burnell as initContainer and healer container in bastion pod

### DIFF
--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -4,7 +4,7 @@ enableTests: yes
 enableProvisionContainer: yes
 extra:
   autoRecovery: no
-  bastion: no
+  bastion: yes
   pulsarMonitor: yes
   burnell: yes
   pulsarHealer: yes

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -1,11 +1,13 @@
 
 persistence: no
 enableTests: yes
+enableProvisionContainer: yes
 extra:
   autoRecovery: no
   bastion: no
   pulsarMonitor: yes
   burnell: yes
+  pulsarHealer: yes
 
 image:
   broker:

--- a/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
@@ -68,6 +68,7 @@ spec:
 {{ toYaml .Values.bastion.tolerations | indent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bastion.gracePeriod }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-burnell"
       volumes:
         {{- if .Values.enableTokenAuth }}
         - name: token-private-key
@@ -113,7 +114,7 @@ spec:
       {{- end }}
       containers:
 {{- if .Values.extra.pulsarHealer }}
-      - name: "{{ template "pulsar.fullname" . }}-burnell-healer" 
+      - name: "{{ template "pulsar.fullname" . }}-burnell" 
         image: "{{ .Values.image.burnell.repository }}:{{ .Values.image.burnell.tag }}"
         imagePullPolicy: {{ .Values.image.burnell.pullPolicy }}
       {{- if .Values.proxy.burnellResources }}

--- a/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
@@ -88,7 +88,61 @@ spec:
           secret:
             secretName: "{{ .Values.tlsSecretName }}" 
         {{- end }}
+      initContainers:
+      {{- if .Values.enableProvisionContainer }}
+      - name: provision-tls-jwt
+        image: "{{ .Values.image.burnell.repository }}:{{ .Values.image.burnell.tag }}"
+        imagePullPolicy: {{ .Values.image.burnell.pullPolicy }}
+      {{- if .Values.proxy.burnellResources }}
+        resources:
+{{ toYaml .Values.proxy.burnellResources | indent 10 }}
+      {{- end }}
+        ports:
+        volumeMounts:
+        env:
+          - name: ClusterName
+            value: "{{ template "pulsar.fullname" . }}"
+          - name: SuperRoles
+            value: {{ .Values.superUserRoles }}
+          - name: ProcessMode
+            value: "init"
+          - name: PulsarNamespace
+            value: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+          - name: LogLevel
+            value: {{ .Values.burnell.logLevel | default "info" }}
+      {{- end }}
       containers:
+{{- if .Values.extra.pulsarHealer }}
+      - name: "{{ template "pulsar.fullname" . }}-burnell-healer" 
+        image: "{{ .Values.image.burnell.repository }}:{{ .Values.image.burnell.tag }}"
+        imagePullPolicy: {{ .Values.image.burnell.pullPolicy }}
+      {{- if .Values.proxy.burnellResources }}
+        resources:
+{{ toYaml .Values.proxy.burnellResources | indent 10 }}
+      {{- end }}
+        ports:
+        - name: burnell
+          containerPort: 8964
+        volumeMounts:
+          {{- if .Values.enableTls }}
+          - name: certs
+            readOnly: true
+            mountPath: /pulsar/certs
+          {{- end }}
+        env:
+          - name: PORT
+            value: "8964"
+          - name: ClusterName
+            value: "{{ template "pulsar.fullname" . }}"
+          - name: SuperRoles
+            value: {{ .Values.superUserRoles }}
+          - name: ProcessMode
+            value: "healer"
+          - name: PulsarNamespace
+            value: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+          - name: LogLevel
+            value: {{ .Values.burnell.logLevel | default "info" }}
+{{- end }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bastion.component }}"
         image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
         imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}

--- a/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
@@ -108,7 +108,7 @@ spec:
           - name: ProcessMode
             value: "init"
           - name: PulsarNamespace
-            value: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+            value: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
           - name: LogLevel
             value: {{ .Values.burnell.logLevel | default "info" }}
       {{- end }}
@@ -140,7 +140,7 @@ spec:
           - name: ProcessMode
             value: "healer"
           - name: PulsarNamespace
-            value: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+            value: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
           - name: LogLevel
             value: {{ .Values.burnell.logLevel | default "info" }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion-deployment.yaml
@@ -108,7 +108,7 @@ spec:
           - name: ProcessMode
             value: "init"
           - name: PulsarNamespace
-            value: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
+            value: {{ .Release.Namespace }}
           - name: LogLevel
             value: {{ .Values.burnell.logLevel | default "info" }}
       {{- end }}
@@ -140,7 +140,7 @@ spec:
           - name: ProcessMode
             value: "healer"
           - name: PulsarNamespace
-            value: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
+            value: {{ .Release.Namespace }}
           - name: LogLevel
             value: {{ .Values.burnell.logLevel | default "info" }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-burnell"
-  namespace: {{ .Values.burnell.PulsarNamespace }}
+  namespace: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -40,5 +40,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-burnell"
-  namespace: {{ .Values.burnell.PulsarNamespace }}
+  namespace: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
@@ -27,6 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-burnell"
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -39,4 +40,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-burnell"
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
@@ -1,0 +1,44 @@
+{{- if or .Values.enableProvisionContainer .Values.extra.pulsarHealer }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-burnell"
+rules:
+- apiGroups: [""]
+  resources:
+  - services
+  - configmaps
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  - secrets
+  - namespaces 
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-burnell"
+  namespace: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-burnell"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ template "pulsar.fullname" . }}-burnell"
+subjects:
+- kind: ServiceAccount
+  name: "{{ template "pulsar.fullname" . }}-burnell"
+  namespace: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-burnell"
-  namespace: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+  namespace: {{ .Values.burnell.PulsarNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -40,5 +40,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-burnell"
-  namespace: {{ .Values.burnell.PulsarNamespace | default "pulsar" }}
+  namespace: {{ .Values.burnell.PulsarNamespace }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/burnell-rbac.yaml
@@ -27,7 +27,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-burnell"
-  namespace: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -40,5 +39,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-burnell"
-  namespace: {{ .Values.burnell.PulsarNamespace | .Release.Namespace }}
 {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -157,7 +157,8 @@ tlsCaCert: ca-certificates.crt
 superUserRoles: superuser,admin,websocket,proxy
 proxyRoles: proxy
 
-
+# Enable auto provisioning of Pulsar keys and JWT
+enableProvisionContainer: no
 
 # Enable token-based authentication and authorization
 enableTokenAuth: no
@@ -265,6 +266,8 @@ extra:
   # Pulsar Monitor
   #
   pulsarMonitor: no
+  # Healer repairs any miconfiguration of Pulsar
+  pulsarHealer: no
   #
   # DEPRECATED
   # Support for the monitoring extra is deprecated


### PR DESCRIPTION
- Add Burnell in `init` mode as the bastion pod's initContainer to provision Pulsar keys and JWTs.
- Add Burnell in `healer` mode as a container in Bastion pod to monitor and repair missing Pulsar keys and JWTs. It can also automatically create new JWT when SuperRoles list is updated as the container's env.
- These two containers are disabled by default
- A new serviceaccount is added to with Kubernetes role binding.