### PR TITLE
set k8s namespace in pulsar-monitor

### DIFF
--- a/helm-chart-sources/pulsar-monitor/templates/configmap.yaml
+++ b/helm-chart-sources/pulsar-monitor/templates/configmap.yaml
@@ -29,6 +29,7 @@ data:
       alertKey: {{ .Values.config.opsGenieAlertKey }}
     k8sConfig:
       enabled: {{ .Values.config.k8sInClusterMonitorEnabled }}
+      pulsarNamespace: {{ .Release.Namespace }}
     brokersConfig:
       {{- toYaml .Values.inclusterBrokerConfig | nindent 6 }}
     pulsarAdminRestConfig:

--- a/helm-chart-sources/pulsar/templates/pulsar-monitor-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-monitor-configmap.yaml
@@ -31,6 +31,7 @@ data:
       alertKey: {{ .Values.pulsarMonitor.config.opsGenieAlertKey }}
     k8sConfig:
       enabled: {{ .Values.pulsarMonitor.config.k8sInClusterMonitorEnabled | default false }}
+      pulsarNamespace: {{ .Release.Namespace }}
     brokersConfig:
       {{- if .Values.pulsarMonitor.config.broker }}
       intervalSeconds: {{ .Values.pulsarMonitor.config.broker.intervalSeconds | default 45 }}


### PR DESCRIPTION
Set Pulsar's Kubernetes namespace for pulsar-monitor. It sources from the .Release.namespace
