### PR TITLE
Istio strict mTLS compatibility for pulsar chart

### DIFF
--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -176,7 +176,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.fullname" . }}.*\]"; do
+            until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ add (.Values.bookkeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Release.Namespace }}; do
               sleep 3;
             done;
       # This initContainer will make sure that the bookkeeper

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -32,6 +32,9 @@ metadata:
     cluster: {{ template "pulsar.fullname" . }}
 spec:
   template:
+    metadata:
+      annotations:
+{{ toYaml .Values.zookeeperMetadata.annotations | indent 8 }}
     spec:
       {{- if .Values.zookeeper.nodeAffinity }}
       affinity:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -581,6 +581,7 @@ zookeepernp:
 ## metadata deployed
 zookeeperMetadata:
   component: zookeeper-metadata
+  annotations: {}
 
 ## Pulsar: Bookkeeper cluster
 ## templates/bookkeeper-statefulset.yaml


### PR DESCRIPTION
To enable strict mTLS with istio for pulsar cluster several things must be tweked

1. zookeper readiness probe for bookkeeper sts - istio proxy is not ready when init container starts and it can't reach zookeeper preventing bookeeper to start normally. there is no easy way right now to enforce behaviour for proxy. solution here is to use default ns probe from other pulsar components in this chart.

2. istio injection can be done in several ways and if its done using annotations zookeeper metadata can't reach zookeeper again in strict mTLS mode because there is no way to set injection annotations for it - no istio proxy when container starts.