### PR TITLE
Explicitly specify machine image for CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
           command: ct lint --config tests/ct.yaml
 
   install-charts:
-    machine: true
+    machine:
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - run:
@@ -27,7 +28,8 @@ jobs:
           no_output_timeout: 1h
 
   release-charts:
-    machine: true
+    machine:
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
Similar issue as what was fixed by https://github.com/datastax/pulsar-helm-chart/pull/69 .
Circle CI documentation: https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

