### PR TITLE
fix multiline strings

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -56,7 +56,7 @@ spec:
         imagePullPolicy: {{ .Values.image.zookeeper.pullPolicy }}
         command: ["sh", "-c"]
         args:
-          - >-
+          - |-
             until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}; do
               sleep 3;
             done;
@@ -70,7 +70,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-          - >
+          - |
             bin/pulsar initialize-cluster-metadata \
               --cluster {{ template "pulsar.fullname" . }} \
               --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} \


### PR DESCRIPTION
Zookeeper has a yaml `zookeeper-metadata.yaml` that contains multiline string fields.
You will see something like this in that file
```yaml
args:
  - >
    bin/pulsar initialize-cluster-metadata \
```

The problem with this is that the main library in Go for parsing yaml contains a [bug](https://github.com/go-yaml/yaml/issues/827) and it is not able to generate the yaml files correctly.


I'm using [Kustomize](https://kustomize.io/) to deploy my helm charts (which uses that yaml library) and that is breaking the deployment.

Yaml also has another syntax for multiline string that works just fine

```yaml
args:
  - |
    bin/pulsar initialize-cluster-metadata \
```